### PR TITLE
fix(api_server): add has_more field to ListInodesResponse for correct is_tru…

### DIFF
--- a/common/protos/nss_ops.proto
+++ b/common/protos/nss_ops.proto
@@ -61,13 +61,14 @@ message ListInodesResponse {
     string err = 2;
   }
 
-  message Inodes {
-    repeated Inode inodes = 3;
+  message Inode {
+    string key = 3;
+    bytes inode = 4;
   }
 
-  message Inode {
-    string key = 4;
-    bytes inode = 5;
+  message Inodes {
+    repeated Inode inodes = 5;
+    bool has_more = 6;
   }
 }
 

--- a/crates/api_server/src/handler/get/list_objects_v2.rs
+++ b/crates/api_server/src/handler/get/list_objects_v2.rs
@@ -315,10 +315,14 @@ pub async fn list_objects(
     .await?;
 
     // Process results
-    let inodes = match resp.result.unwrap() {
+    let (inodes, has_more) = match resp.result.unwrap() {
         list_inodes_response::Result::Ok(res) => {
-            tracing::debug!("NSS returned {} inodes", res.inodes.len());
-            res.inodes
+            tracing::debug!(
+                "NSS returned {} inodes, has_more={}",
+                res.inodes.len(),
+                res.has_more
+            );
+            (res.inodes, res.has_more)
         }
         list_inodes_response::Result::Err(e) => {
             tracing::error!("NSS list_inodes error: {}", e);
@@ -350,7 +354,7 @@ pub async fn list_objects(
         }
     }
 
-    let next_continuation_token = if inodes.len() < max_keys as usize {
+    let next_continuation_token = if !has_more {
         None
     } else {
         inodes


### PR DESCRIPTION
The S3 ListObjectsV2 API was incorrectly setting is_truncated based on a heuristic (comparing inodes.len() with max_keys). This caused pagination to break when the number of returned objects happened to equal max_keys but there were still more objects.

This change adds an explicit has_more field to the ListInodesResponse proto message, which is set by the NSS backend based on whether there are more entries to list. The API server now uses this field instead of the flawed heuristic.