### PR TITLE
enhance nightly test

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+chrono.workspace = true
 cmd_lib.workspace = true
 env_logger.workspace = true
 rlimit.workspace = true


### PR DESCRIPTION
- Stop all services before running to ensure clean environment
- Organize logs into data/logs/nightly/<YYYYMMDD_HHMMSS>
