### PR TITLE
Introduce Mount helper to decouple mount lifetime from filesystem

### DIFF
--- a/crates/fs_server/fractal-fuse/src/mount.rs
+++ b/crates/fs_server/fractal-fuse/src/mount.rs
@@ -1,15 +1,42 @@
 use std::ffi::OsString;
 use std::io::{self, IoSliceMut};
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 use nix::sys::socket::{self, AddressFamily, ControlMessageOwned, MsgFlags, SockFlag, SockType};
-use tracing::debug;
+use tracing::{debug, warn};
 
 fn find_fusermount3() -> io::Result<std::path::PathBuf> {
     which::which("fusermount3")
         .map_err(|err| io::Error::other(format!("find fusermount3 binary failed {err:?}")))
+}
+
+pub struct Mount {
+    fd: OwnedFd,
+    path: PathBuf,
+}
+
+impl Mount {
+    pub fn new(mount_options: &MountOptions, path: PathBuf) -> io::Result<Self> {
+        let fd = fusermount(mount_options, &path)?;
+        Ok(Self { fd, path })
+    }
+}
+
+impl AsFd for Mount {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+}
+
+impl Drop for Mount {
+    fn drop(&mut self) {
+        if let Err(e) = fusermount_unmount(&self.path) {
+            warn!("unmount failed: {}", e);
+        }
+    }
 }
 
 /// Mount a FUSE filesystem using fusermount3 (unprivileged mount).

--- a/crates/fs_server/fractal-fuse/src/session.rs
+++ b/crates/fs_server/fractal-fuse/src/session.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::io;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -56,7 +56,7 @@ fn unregister_files() -> io::Result<()> {
 use crate::abi::*;
 use crate::dispatch;
 use crate::filesystem::Filesystem;
-use crate::mount::{self, MountOptions};
+use crate::mount::{self, Mount, MountOptions};
 use crate::ring::*;
 
 /// Default max_write size (1MB).
@@ -81,6 +81,11 @@ impl Session {
         self
     }
 
+    pub fn run_with_mount<F: Filesystem>(self, fs: F, mount: &Mount) -> io::Result<()> {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        self.run_inner(fs, mount.as_fd(), shutdown)
+    }
+
     /// Mount, negotiate FUSE_INIT, setup io_uring rings, and run until shutdown.
     /// This function blocks the calling thread.
     pub fn run<F: Filesystem>(self, fs: F, mount_path: &Path) -> io::Result<()> {
@@ -92,7 +97,7 @@ impl Session {
 
         let shutdown = Arc::new(AtomicBool::new(false));
 
-        let result = self.run_inner(fs, &fuse_fd, shutdown);
+        let result = self.run_inner(fs, fuse_fd.as_fd(), shutdown);
 
         // Phase 4: Unmount
         info!("unmounting {:?}", mount_path);
@@ -106,7 +111,7 @@ impl Session {
     fn run_inner<F: Filesystem>(
         &self,
         fs: F,
-        fuse_fd: &OwnedFd,
+        fuse_fd: BorrowedFd<'_>,
         shutdown: Arc<AtomicBool>,
     ) -> io::Result<()> {
         // Phase 2: FUSE_INIT over blocking /dev/fuse


### PR DESCRIPTION
Fixes #16.

This is a minimal approach: existing APIs are left in place to avoid breakage, and no effort is made to manage the lifetime of `FuseNotifier`'s FD. Follow-up work might include:
- Moving `FuseNotifier`'s methods onto `Mount`
- Removing/replacing the existing `Session::run` outright