### PR TITLE
feat(fractal-fuse): async Filesystem::forget

### DIFF
--- a/crates/fs_server/fractal-fuse/src/dispatch.rs
+++ b/crates/fs_server/fractal-fuse/src/dispatch.rs
@@ -28,7 +28,7 @@ pub async fn dispatch<F: Filesystem>(fs: &F, entry: &mut RingEntry) -> Option<()
     match opcode {
         FUSE_FORGET => {
             let arg: &fuse_forget_in = header.op_in_as();
-            fs.forget(req, nodeid, arg.nlookup);
+            fs.forget(req, nodeid, arg.nlookup).await;
             return None;
         }
         FUSE_BATCH_FORGET => {
@@ -45,7 +45,7 @@ pub async fn dispatch<F: Filesystem>(fs: &F, entry: &mut RingEntry) -> Option<()
                 let one = unsafe { &*(payload.as_ptr().add(offset) as *const fuse_forget_one) };
                 inodes.push((one.nodeid, one.nlookup));
             }
-            fs.batch_forget(req, &inodes);
+            fs.batch_forget(req, &inodes).await;
             return None;
         }
         _ => {}

--- a/crates/fs_server/fractal-fuse/src/filesystem.rs
+++ b/crates/fs_server/fractal-fuse/src/filesystem.rs
@@ -55,17 +55,29 @@ pub trait Filesystem: Send + Sync + 'static {
     /// `nlookup` is the number of references to drop. The filesystem should
     /// not return errors; after this call, the inode may be evicted if no
     /// references remain.
-    fn forget(&self, req: Request, inode: Inode, nlookup: u64) {
+    fn forget(
+        &self,
+        req: Request,
+        inode: Inode,
+        nlookup: u64,
+    ) -> impl std::future::Future<Output = ()> {
         let _ = (req, inode, nlookup);
+        async {}
     }
 
     /// Release multiple inode references in a single call.
     ///
     /// Each element in `inodes` is an `(inode, nlookup)` pair. The default
     /// implementation delegates to `forget` for each entry.
-    fn batch_forget(&self, req: Request, inodes: &[(Inode, u64)]) {
-        for &(inode, nlookup) in inodes {
-            self.forget(req, inode, nlookup);
+    fn batch_forget(
+        &self,
+        req: Request,
+        inodes: &[(Inode, u64)],
+    ) -> impl std::future::Future<Output = ()> {
+        async move {
+            for &(inode, nlookup) in inodes {
+                self.forget(req, inode, nlookup).await;
+            }
         }
     }
 

--- a/crates/fs_server/src/fuse_server.rs
+++ b/crates/fs_server/src/fuse_server.rs
@@ -67,7 +67,7 @@ impl Filesystem for FuseServer {
         })
     }
 
-    fn forget(&self, _req: Request, inode: u64, nlookup: u64) {
+    async fn forget(&self, _req: Request, inode: u64, nlookup: u64) {
         self.vfs.vfs_forget(inode, nlookup);
     }
 


### PR DESCRIPTION
It's not obvious why this is currently synchronous, and it's convenient for it not to be e.g. if you might cache writes in an inode.