### PR TITLE
chore(deps): upgrade compio 0.11 -> 0.12, io-uring -> 0.7.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,12 +129,12 @@ anyhow = "1.0.102"
 regex = "1.12.3"
 core_affinity = "0.8"
 urlencoding = "2"
-compio-runtime = { version = "0.11", features = ["time"] }
-compio-net = "0.11"
-compio-io = "0.9"
+compio-runtime = { version = "0.12", features = ["time"] }
+compio-net = "0.12"
+compio-io = "0.10"
 compio-buf = "0.8"
-compio-fs = "0.11"
-compio-macros = "0.1"
+compio-fs = "0.12"
+compio-macros = "0.2"
 libc = "0.2"
 nix = { version = "0.31", features = ["fs"] }
 firestore = "0.43"

--- a/crates/common/rpc_clients/client_common/src/generic_client.rs
+++ b/crates/common/rpc_clients/client_common/src/generic_client.rs
@@ -306,7 +306,7 @@ where
     }
 
     async fn send_task(
-        mut writer: compio_net::OwnedWriteHalf<compio_net::TcpStream>,
+        mut writer: compio_net::TcpStream,
         mut receiver: Receiver<ZcMessageFrame<Header>>,
         socket_fd: RawFd,
         rpc_type: &'static str,
@@ -375,7 +375,7 @@ where
     }
 
     async fn receive_task(
-        mut reader: compio_net::OwnedReadHalf<compio_net::TcpStream>,
+        mut reader: compio_net::TcpStream,
         requests: &RequestMap<Header>,
         socket_fd: RawFd,
         rpc_type: &'static str,

--- a/crates/fs_server/fractal-fuse/Cargo.toml
+++ b/crates/fs_server/fractal-fuse/Cargo.toml
@@ -10,14 +10,13 @@ keywords = ["fuse", "io-uring", "filesystem", "async", "linux"]
 categories = ["filesystem", "asynchronous", "os::linux-apis"]
 
 [dependencies]
-io-uring = "0.7"
-compio-runtime = { version = "0.11", features = ["time"] }
-compio-driver = { version = "0.11", features = ["io-uring-sqe128"] }
+io-uring = "0.7.12"
+compio-runtime = { version = "0.12", features = ["time"] }
+compio-driver = { version = "0.12", features = ["io-uring-sqe128"] }
 libc = "0.2"
 nix = { version = "0.31", features = ["fs", "socket", "uio"] }
 tracing = "0.1"
 which = "8"
-pin-project-lite = "0.2"
 tokio-util = "0.7.18"
 futures-util = "0.3"
 

--- a/crates/fs_server/fractal-fuse/src/abi.rs
+++ b/crates/fs_server/fractal-fuse/src/abi.rs
@@ -764,4 +764,12 @@ const _: () = {
     assert!(size_of::<fuse_notify_inval_inode_out>() == 24);
     assert!(size_of::<fuse_notify_inval_entry_out>() == 16);
     assert!(size_of::<fuse_notify_delete_out>() == 24);
+    // Dirent/entry sizes are load-bearing for the readdir(plus) wire format:
+    // the kernel parses names at offsetof(name), which equals size_of here only
+    // because these structs have no trailing padding. Guard that invariant so a
+    // future field/layout change can't silently corrupt the dirent stream.
+    assert!(size_of::<fuse_attr>() == 88);
+    assert!(size_of::<fuse_entry_out>() == 128);
+    assert!(size_of::<fuse_dirent>() == 24);
+    assert!(size_of::<fuse_direntplus>() == 152);
 };

--- a/crates/fs_server/fractal-fuse/src/ring.rs
+++ b/crates/fs_server/fractal-fuse/src/ring.rs
@@ -1,14 +1,11 @@
 use std::io;
-use std::marker::PhantomPinned;
 use std::mem::size_of;
-use std::pin::Pin;
 use std::ptr;
 
 use compio_driver::{OpCode, OpEntry};
 use io_uring::opcode::UringCmd80;
 use io_uring::squeue::Entry128;
 use io_uring::types::Fixed;
-use pin_project_lite::pin_project;
 
 use crate::abi::*;
 
@@ -179,15 +176,11 @@ fn build_cmd(qid: u16, commit_id: u64) -> [u8; 80] {
     cmd
 }
 
-pin_project! {
-    /// FUSE REGISTER operation: registers a ring entry's buffers with the kernel
-    /// and fetches the first request.
-    pub struct FuseRegister {
-        iov_ptr: u64,
-        qid: u16,
-        #[pin]
-        _pin: PhantomPinned,
-    }
+/// FUSE REGISTER operation: registers a ring entry's buffers with the kernel
+/// and fetches the first request.
+pub struct FuseRegister {
+    iov_ptr: u64,
+    qid: u16,
 }
 
 impl FuseRegister {
@@ -195,27 +188,16 @@ impl FuseRegister {
         Self {
             iov_ptr: entry.iov_ptr() as u64,
             qid,
-            _pin: PhantomPinned,
         }
     }
-}
-
-/// Patch the `addr` field (offset 16) in the raw SQE inside an Entry128.
-///
-/// The upstream io-uring crate (0.7.x) does not expose a setter for `sqe.addr`
-/// on `UringCmd80`. The field sits at a fixed kernel-ABI offset (16 bytes into
-/// `io_uring_sqe`), so we write it directly.
-unsafe fn set_sqe_addr(entry: &mut Entry128, addr: u64) {
-    const _: () = assert!(size_of::<Entry128>() == 128);
-    let ptr = entry as *mut Entry128 as *mut u8;
-    unsafe { ptr.add(16).cast::<u64>().write(addr) };
 }
 
 /// Patch the `len` field (offset 24) in the raw SQE inside an Entry128.
 ///
 /// The upstream io-uring crate does not expose a setter for `sqe.len` on
-/// `UringCmd80`. The field sits at a fixed kernel-ABI offset (24 bytes into
-/// `io_uring_sqe`), so we write it directly.
+/// `UringCmd80` (unlike `addr`, which gained a builder in 0.7.12). The field
+/// sits at a fixed kernel-ABI offset (24 bytes into `io_uring_sqe`), so we
+/// write it directly.
 unsafe fn set_sqe_len(entry: &mut Entry128, len: u32) {
     const _: () = assert!(size_of::<Entry128>() == 128);
     let ptr = entry as *mut Entry128 as *mut u8;
@@ -223,48 +205,44 @@ unsafe fn set_sqe_len(entry: &mut Entry128, len: u32) {
 }
 
 unsafe impl OpCode for FuseRegister {
-    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
-        let this = self.project();
-        let cmd = build_cmd(*this.qid, 0);
+    // No self-references are held across the operation; the iovec pointer
+    // refers to externally-owned, pinned `RingEntry` memory.
+    type Control = ();
 
+    fn create_entry(&mut self, _: &mut Self::Control) -> OpEntry {
+        let cmd = build_cmd(self.qid, 0);
+
+        // `addr` carries the iovec pointer; builder setter added in io-uring 0.7.12.
         let mut entry = UringCmd80::new(Fixed(FUSE_FD_INDEX), FUSE_IO_URING_CMD_REGISTER)
             .cmd(cmd)
+            .addr(Some(self.iov_ptr))
             .build();
 
-        // Set iovec pointer — upstream UringCmd80 doesn't expose .addr() yet
-        unsafe { set_sqe_addr(&mut entry, *this.iov_ptr) };
-        // Set iovec count (2) via raw SQE poke — upstream has no .len() setter
+        // Set iovec count (2) via raw SQE poke -- upstream has no .len() setter
         unsafe { set_sqe_len(&mut entry, 2) };
 
         entry.into()
     }
 }
 
-pin_project! {
-    /// FUSE COMMIT_AND_FETCH operation: sends a response to the kernel and
-    /// atomically fetches the next request into the same buffers.
-    pub struct FuseCommitAndFetch {
-        qid: u16,
-        commit_id: u64,
-        #[pin]
-        _pin: PhantomPinned,
-    }
+/// FUSE COMMIT_AND_FETCH operation: sends a response to the kernel and
+/// atomically fetches the next request into the same buffers.
+pub struct FuseCommitAndFetch {
+    qid: u16,
+    commit_id: u64,
 }
 
 impl FuseCommitAndFetch {
     pub fn new(qid: u16, commit_id: u64) -> Self {
-        Self {
-            qid,
-            commit_id,
-            _pin: PhantomPinned,
-        }
+        Self { qid, commit_id }
     }
 }
 
 unsafe impl OpCode for FuseCommitAndFetch {
-    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
-        let this = self.project();
-        let cmd = build_cmd(*this.qid, *this.commit_id);
+    type Control = ();
+
+    fn create_entry(&mut self, _: &mut Self::Control) -> OpEntry {
+        let cmd = build_cmd(self.qid, self.commit_id);
 
         UringCmd80::new(Fixed(FUSE_FD_INDEX), FUSE_IO_URING_CMD_COMMIT_AND_FETCH)
             .cmd(cmd)

--- a/crates/fs_server/fractal-fuse/src/session.rs
+++ b/crates/fs_server/fractal-fuse/src/session.rs
@@ -8,54 +8,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::thread;
 
-use compio_runtime::Runtime;
+use compio_runtime::{Runtime, register_files, unregister_files};
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
-
-const IORING_REGISTER_FILES: libc::c_uint = 2;
-const IORING_UNREGISTER_FILES: libc::c_uint = 3;
-
-/// Register fixed files with the current thread's io_uring instance.
-///
-/// This calls the `io_uring_register` syscall directly because the published
-/// compio-runtime (0.11.x) does not yet expose `register_files`.
-fn register_files(fds: &[i32]) -> io::Result<()> {
-    let ring_fd = Runtime::with_current(|rt| rt.as_raw_fd());
-    let ret = unsafe {
-        libc::syscall(
-            libc::SYS_io_uring_register,
-            ring_fd as libc::c_uint,
-            IORING_REGISTER_FILES,
-            fds.as_ptr(),
-            fds.len() as libc::c_uint,
-        )
-    };
-    if ret < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
-}
-
-/// Unregister fixed files from the current thread's io_uring instance.
-fn unregister_files() -> io::Result<()> {
-    let ring_fd = Runtime::with_current(|rt| rt.as_raw_fd());
-    let ret = unsafe {
-        libc::syscall(
-            libc::SYS_io_uring_register,
-            ring_fd as libc::c_uint,
-            IORING_UNREGISTER_FILES,
-            std::ptr::null::<libc::c_void>(),
-            0u32,
-        )
-    };
-    if ret < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
-}
 
 use crate::abi::*;
 use crate::dispatch;
@@ -481,15 +437,11 @@ async fn run_worker<F: Filesystem>(
                 shutdown.cancel();
             }
             Err(e) => {
-                if let Some(msg) = e
-                    .downcast_ref::<String>()
-                    .map(|x| &**x)
-                    .or_else(|| e.downcast_ref::<&str>().copied())
-                {
-                    error!("entry task panicked: {}", msg);
-                } else {
-                    error!("entry task panicked");
-                }
+                // `e` is compio's JoinError; its Display reports whether the
+                // task was cancelled or panicked. The panic payload message
+                // itself is already emitted to stderr by the default panic
+                // hook when the task unwinds, so there's no need to downcast.
+                error!("entry task aborted: {}", e);
                 failed = true;
                 shutdown.cancel();
             }


### PR DESCRIPTION
## Summary

Upgrades `compio` 0.11 -> 0.12 and `io-uring` -> 0.7.12, then removes the
hand-rolled workarounds in `fractal-fuse` that existed only because the old
upstream versions didn't expose the needed APIs. Net **-114/+43** lines.

### Hacks eliminated
- **`register_files` / `unregister_files`** raw `io_uring_register` syscalls -> `compio_runtime::{register_files, unregister_files}`.
- **`set_sqe_addr`** raw SQE poke at offset 16 -> `UringCmd80::addr()` builder (added in io-uring 0.7.12). `set_sqe_len` stays -- there is still no `len` setter on `UringCmd80`.
- **`pin_project!` + `PhantomPinned`** on the `OpCode` impls -> plain structs. The new `compio-driver` `OpCode` trait takes `&mut self` + a `Control` assoc type instead of `Pin<&mut Self>`, so the ops no longer need pinning. Dropped the now-unused `pin-project-lite` dependency.

### Other 0.12 API breaks adapted
- `JoinError` is now an enum -> log via `Display` (the panic payload still reaches stderr via the default panic hook).
- `TcpStream::into_split` returns two refcounted `TcpStream` clones instead of distinct `Owned{Read,Write}Half` types. Cleanup is unchanged (`libc::shutdown` on the raw fd in `Drop`), so behavior is identical.

## Toolchain requirement
Requires **rustc >= 1.96**: compio 0.12's deps use `cfg_select` and `maybe_uninit_slice`, which stabilized in 1.96. CI/deploy toolchains pinned below 1.96 must be bumped.

## Verification
- `just run-tests fs-server` passes -- live FUSE mount exercises the REGISTER / COMMIT_AND_FETCH io_uring path (mount lifecycle + disk-cache populate/hit/cold-start).
- `cargo check --workspace --all-targets`, `cargo clippy`, `cargo fmt --check`, and `fractal-fuse` unit tests all clean.