### PR TITLE
feat(fs_server): inode-scoped write lock + sparse-override prereqs

### DIFF
--- a/crates/api_server/src/handler/post/create_multipart_upload.rs
+++ b/crates/api_server/src/handler/post/create_multipart_upload.rs
@@ -60,6 +60,7 @@ pub async fn create_multipart_upload_handler(
         version_id,
         block_size: ObjectLayout::DEFAULT_BLOCK_SIZE,
         timestamp,
+        blob_version: 1,
         state: ObjectState::Mpu(MpuState::Uploading),
     };
     let object_layout_bytes: Bytes = to_bytes_in::<_, Error>(&object_layout, Vec::new())?.into();

--- a/crates/api_server/src/handler/put/put_object.rs
+++ b/crates/api_server/src/handler/put/put_object.rs
@@ -450,6 +450,7 @@ async fn put_object_streaming_internal(
         version_id,
         block_size: ObjectLayout::DEFAULT_BLOCK_SIZE,
         timestamp,
+        blob_version: 1,
         state: ObjectState::Normal(ObjectMetaData {
             blob_guid,
             core_meta_data: ObjectCoreMetaData {
@@ -666,6 +667,7 @@ async fn put_object_with_no_trailer(
         version_id,
         block_size: ObjectLayout::DEFAULT_BLOCK_SIZE,
         timestamp,
+        blob_version: 1,
         state: ObjectState::Normal(ObjectMetaData {
             blob_guid,
             core_meta_data: ObjectCoreMetaData {

--- a/crates/common/data_types/src/object_layout.rs
+++ b/crates/common/data_types/src/object_layout.rs
@@ -24,6 +24,10 @@ pub struct ObjectLayout {
     pub timestamp: u64,
     pub version_id: Uuid, // v4
     pub block_size: u32,
+    /// Monotonic version for in-place block override (V1 sparse + override).
+    /// Incremented by `PutInodeCas` on every flush that has pending work.
+    /// `0` is reserved for legacy / pre-V1 layouts; new flushes start at `1`.
+    pub blob_version: u64,
     pub state: ObjectState,
 }
 

--- a/crates/common/file_ops/src/lib.rs
+++ b/crates/common/file_ops/src/lib.rs
@@ -170,6 +170,7 @@ pub fn create_dir_marker_layout() -> ObjectLayout {
             .as_millis() as u64,
         version_id: ObjectLayout::gen_version_id(),
         block_size: ObjectLayout::DEFAULT_BLOCK_SIZE,
+        blob_version: 1,
         state: ObjectState::Normal(ObjectMetaData {
             blob_guid: DataBlobGuid {
                 blob_id: uuid::Uuid::nil(),

--- a/crates/fractal-vfs/src/error.rs
+++ b/crates/fractal-vfs/src/error.rs
@@ -25,6 +25,9 @@ pub enum FsError {
     #[error("bad file descriptor")]
     BadFd,
 
+    #[error("file is busy: another writer holds the inode-scoped write lock")]
+    Busy,
+
     #[error("RPC error: {0}")]
     Rpc(#[from] RpcError),
 
@@ -51,6 +54,7 @@ impl From<FsError> for io::Error {
             FsError::NotDir => io::Error::from_raw_os_error(libc::ENOTDIR),
             FsError::ReadOnly => io::Error::from_raw_os_error(libc::EROFS),
             FsError::BadFd => io::Error::from_raw_os_error(libc::EBADF),
+            FsError::Busy => io::Error::from_raw_os_error(libc::EBUSY),
             FsError::Rpc(ref e) => {
                 if e.retryable() {
                     io::Error::from_raw_os_error(libc::EAGAIN)

--- a/crates/fractal-vfs/src/vfs.rs
+++ b/crates/fractal-vfs/src/vfs.rs
@@ -96,6 +96,11 @@ pub struct VfsCore {
     // Tracks blob data for unlinked files that still have open handles.
     // Cleanup is deferred until the last handle is released.
     deferred_blob_cleanup: DashMap<u64, Bytes>,
+    // Inode-scoped write lock. At most one write-mode handle per inode is
+    // allowed. Map value is the owning fh so a stale lock for a closed fh
+    // can be reclaimed by the next opener. Reads do not touch
+    // this lock.
+    inode_write_owner: DashMap<u64, u64>,
 }
 
 impl VfsCore {
@@ -146,6 +151,7 @@ impl VfsCore {
             passthrough_max_object_size,
             fuse_dev_fd: None,
             deferred_blob_cleanup: DashMap::new(),
+            inode_write_owner: DashMap::new(),
         }
     }
 
@@ -198,6 +204,37 @@ impl VfsCore {
         self.file_handles.iter().any(|entry| {
             entry.value().ino == ino && exclude_fh.is_none_or(|excl| *entry.key() != excl)
         })
+    }
+
+    /// Acquire the inode-scoped write lock for `fh`. Returns `Busy` if another
+    /// write-mode handle currently owns it.
+    ///
+    /// Reclaim rule: if the recorded owner fh has been released (no entry in
+    /// `file_handles`), the lock is stale and we take it. This recovers from
+    /// any path that removes a handle without first calling
+    /// `release_write_lock` (e.g. lookup races during shutdown).
+    fn acquire_write_lock(&self, inode: u64, fh: u64) -> Result<(), FsError> {
+        use dashmap::mapref::entry::Entry;
+        match self.inode_write_owner.entry(inode) {
+            Entry::Vacant(slot) => {
+                slot.insert(fh);
+                Ok(())
+            }
+            Entry::Occupied(mut slot) => {
+                let owner = *slot.get();
+                if !self.file_handles.contains_key(&owner) {
+                    slot.insert(fh);
+                    Ok(())
+                } else {
+                    Err(FsError::Busy)
+                }
+            }
+        }
+    }
+
+    fn release_write_lock(&self, inode: u64, fh: u64) {
+        self.inode_write_owner
+            .remove_if(&inode, |_, owner| *owner == fh);
     }
 
     fn file_perm(&self) -> u16 {
@@ -1141,6 +1178,15 @@ impl VfsCore {
         let layout = entry.layout.clone();
         drop(entry);
 
+        // Enforce single-writer per inode. The first writer
+        // wins and subsequent write-mode opens fail with EBUSY. The lock
+        // is process-local in-memory state and dies with the process on
+        // crash, so the next open reacquires.
+        let fh = self.alloc_fh();
+        if is_write {
+            self.acquire_write_lock(inode, fh)?;
+        }
+
         // Resolve layout if not cached
         let layout = match layout {
             Some(l) => Some(l),
@@ -1161,7 +1207,13 @@ impl VfsCore {
             {
                 // Existing file without truncate: preload content so partial
                 // writes don't lose surrounding data
-                let data = self.preload_file_content(&s3_key, l).await?;
+                let data = match self.preload_file_content(&s3_key, l).await {
+                    Ok(d) => d,
+                    Err(e) => {
+                        self.release_write_lock(inode, fh);
+                        return Err(e);
+                    }
+                };
                 Some(WriteBuffer { data, dirty: false })
             } else {
                 // O_TRUNC or new file: start empty
@@ -1174,7 +1226,6 @@ impl VfsCore {
             None
         };
 
-        let fh = self.alloc_fh();
         self.file_handles.insert(
             fh,
             FileHandle {
@@ -1247,11 +1298,15 @@ impl VfsCore {
 
     pub async fn vfs_release(&self, fh: u64) -> Result<(), FsError> {
         // Flush any dirty write buffer before releasing
-        let has_dirty = self
+        let (has_dirty, was_writer) = self
             .file_handles
             .get(&fh)
-            .map(|h| h.write_buf.as_ref().map(|wb| wb.dirty).unwrap_or(false))
-            .unwrap_or(false);
+            .map(|h| {
+                let dirty = h.write_buf.as_ref().map(|wb| wb.dirty).unwrap_or(false);
+                let writer = h.write_buf.is_some();
+                (dirty, writer)
+            })
+            .unwrap_or((false, false));
 
         if has_dirty {
             self.flush_write_buffer(fh).await?;
@@ -1260,6 +1315,12 @@ impl VfsCore {
         // Get the inode before removing the handle
         let ino = self.file_handles.get(&fh).map(|h| h.ino);
         self.file_handles.remove(&fh);
+
+        // Release the inode-scoped write lock if this handle held it.
+        // Read-only handles never acquired it.
+        if was_writer && let Some(ino) = ino {
+            self.release_write_lock(ino, fh);
+        }
 
         // Handle deferred blob cleanup for unlinked files
         if let Some(ino) = ino
@@ -1293,6 +1354,10 @@ impl VfsCore {
         let (ino, _) = self.inodes.lookup_or_insert(&key, EntryType::File, None);
 
         let fh = self.alloc_fh();
+        // vfs_create implicitly opens the new file for writing,
+        // so it must obey the inode-scoped write lock. A re-create on an
+        // inode that already has a live write handle returns EBUSY.
+        self.acquire_write_lock(ino, fh)?;
         self.file_handles.insert(
             fh,
             FileHandle {

--- a/crates/fractal-vfs/src/vfs.rs
+++ b/crates/fractal-vfs/src/vfs.rs
@@ -824,6 +824,7 @@ impl VfsCore {
             version_id: ObjectLayout::gen_version_id(),
             block_size: DEFAULT_BLOCK_SIZE,
             timestamp,
+            blob_version: 1,
             state: ObjectState::Normal(ObjectMetaData {
                 blob_guid,
                 core_meta_data: ObjectCoreMetaData {

--- a/justfile
+++ b/justfile
@@ -13,6 +13,9 @@ nightly *args:
 run-tests *args:
   cargo xtask run-tests {{args}}
 
+fstest *args:
+  cargo xtask run-tests pjdfstest {{args}}
+
 deploy *args:
   cargo xtask deploy {{args}}
 

--- a/third_party/index.md
+++ b/third_party/index.md
@@ -5,6 +5,16 @@ These are used for local development:
 1. [dynamodb local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)
 2. [minio](https://github.com/minio/minio)
 
-There are used for benchmark in a deployed vpc environment:
+These are used for benchmark in a deployed vpc environment:
 
 1. [s3 benchmark tools](https://github.com/minio/warp/releases/tag/v1.3.0)
+
+These are used for filesystem testing (fs_server FUSE mount):
+
+1. [pjdfstest](https://github.com/pjd/pjdfstest) -- POSIX filesystem
+   compliance test suite (`chmod`, `chown`, `link`, `mkdir`, `mkfifo`,
+   `open`, `rename`, `rmdir`, `symlink`, `truncate`, `unlink`,
+   `chflags`, `granular`). Driven via `cargo xtask run-tests pjdfstest`,
+   which clones and builds the suite under `data/third_party/pjdfstest/`
+   on first run, then runs `prove -r tests/` from the FUSE mount root
+   in `mode=default` so the writeback queue is exercised.

--- a/xtask/src/cmd_run_tests.rs
+++ b/xtask/src/cmd_run_tests.rs
@@ -135,6 +135,13 @@ pub async fn run_tests(test_type: TestType) -> CmdResult {
         TestType::BssRepair => test_bss_repair().await,
         TestType::NssFailover => test_nss_failover(RssBackend::Etcd).await,
         TestType::FsServer { disk_cache_only } => test_fs_server(disk_cache_only).await,
+        TestType::Pjdfstest { subdir } => {
+            cmd_service::init_service(ServiceName::All, BuildMode::Debug, &InitConfig::default())?;
+            cmd_service::start_service(ServiceName::All)?;
+            let result = fs_server::pjdfs::run_pjdfstest(subdir.as_deref()).await;
+            cmd_service::stop_service(ServiceName::All)?;
+            result
+        }
         TestType::All => {
             test_fs_server(false).await?;
             test_bss_node_failure().await?;

--- a/xtask/src/cmd_run_tests/fs_server.rs
+++ b/xtask/src/cmd_run_tests/fs_server.rs
@@ -1,4 +1,5 @@
 pub mod fuse;
+pub mod pjdfs;
 
 use crate::CmdResult;
 use cmd_lib::*;

--- a/xtask/src/cmd_run_tests/fs_server/pjdfs.rs
+++ b/xtask/src/cmd_run_tests/fs_server/pjdfs.rs
@@ -1,0 +1,255 @@
+//! pjdfstest driver. Clones, bootstraps, and runs the POSIX
+//! filesystem compliance suite against an fs_server FUSE mount in
+//! `writeback_mode=default` so the writeback queue path is exercised.
+//!
+//! pjdfstest is a third-party C + Perl test suite that walks the
+//! POSIX system-call surface (`chmod`, `chown`, `link`, `mkdir`,
+//! `mkfifo`, `open`, `rename`, `rmdir`, `symlink`, `truncate`,
+//! `unlink`, `chflags`, `granular`). Each `.t` file under `tests/` is
+//! a TAP-format prove(1) script that calls the local `pjdfstest`
+//! binary with a small fixed grammar.
+//!
+//! Failures are documented but not fatal: many subdirs assume
+//! Linux/BSD-specific features (chflags, capabilities, ACLs) that
+//! fs_server intentionally doesn't expose. The promotion gate looks
+//! at the regression delta against strict mode, not the absolute
+//! pass count.
+
+use crate::cmd_service;
+use crate::{CmdResult, FsServerConfig, InitConfig, ServiceName};
+use cmd_lib::run_cmd;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use super::MOUNT_POINT;
+
+const PJDFSTEST_REPO: &str = "https://github.com/pjd/pjdfstest.git";
+const PJDFSTEST_DIR: &str = "data/third_party/pjdfstest";
+/// Pinned upstream commit. pjdfstest publishes no release tags, so we
+/// pin by SHA to keep the suite reproducible: an upstream regression on
+/// `master` can't silently break our runs, and the pass/fail counts
+/// stay comparable across machines and over time. Bump this only after
+/// re-validating the full suite against the new revision.
+const PJDFSTEST_COMMIT: &str = "ededbeb2b44929972898afb87474b0937f78a877";
+
+fn pjdfstest_path() -> PathBuf {
+    let base = std::env::current_dir().expect("cwd");
+    base.join(PJDFSTEST_DIR)
+}
+
+fn pjdfstest_binary() -> PathBuf {
+    pjdfstest_path().join("pjdfstest")
+}
+
+fn require_build_tools() -> CmdResult {
+    let needed = ["cc", "prove", "perl", "git"];
+    let mut missing: Vec<&str> = Vec::new();
+    for tool in &needed {
+        if run_cmd!(which $tool &>/dev/null).is_err() {
+            missing.push(*tool);
+        }
+    }
+    if !missing.is_empty() {
+        return Err(std::io::Error::other(format!(
+            "Missing build tools required by pjdfstest: {missing:?}\n  \
+             Install via: sudo apt install -y build-essential perl git"
+        )));
+    }
+    Ok(())
+}
+
+/// Hand-rolled `config.h` for Linux glibc. pjdfstest's upstream uses
+/// autoconf to discover which `*at` syscalls and stat-timespec field
+/// shapes the host has; we know the answers for Linux, so we sidestep
+/// the autotools chain entirely. BSD-only flags
+/// (`chflags`, `lchmod`, etc.) stay undefined so pjdfstest skips
+/// those code paths.
+const LINUX_CONFIG_H: &str = r#"/* Hand-rolled config.h for Linux glibc. See
+ * xtask/src/cmd_run_tests/fs_server/pjdfs.rs for the source.
+ */
+#define HAVE_FACCESSAT 1
+#define HAVE_FCHMODAT 1
+#define HAVE_FCHOWNAT 1
+#define HAVE_FSTATAT 1
+#define HAVE_LINKAT 1
+#define HAVE_MKDIRAT 1
+#define HAVE_MKFIFOAT 1
+#define HAVE_MKNODAT 1
+#define HAVE_OPENAT 1
+#define HAVE_POSIX_FALLOCATE 1
+#define HAVE_RENAMEAT 1
+#define HAVE_SYMLINKAT 1
+#define HAVE_UNLINKAT 1
+#define HAVE_UTIMENSAT 1
+#define HAVE_SYS_SYSMACROS_H 1
+#define HAVE_STRUCT_STAT_ST_ATIM 1
+#define HAVE_STRUCT_STAT_ST_CTIM 1
+#define HAVE_STRUCT_STAT_ST_MTIM 1
+"#;
+
+fn ensure_pjdfstest_built() -> CmdResult {
+    require_build_tools()?;
+    let path = pjdfstest_path();
+    let binary = pjdfstest_binary();
+    if binary.exists() {
+        println!("  pjdfstest already built at {}", binary.display());
+        return Ok(());
+    }
+    let parent = path.parent().expect("parent of pjdfstest_dir");
+    std::fs::create_dir_all(parent)?;
+
+    let path_str = path.to_string_lossy().to_string();
+    if !path.exists() {
+        println!("  cloning pjdfstest at {PJDFSTEST_COMMIT} into {path_str}");
+        // Shallow fetch of the pinned commit only (GitHub serves
+        // reachable SHAs), so we get exactly the validated revision
+        // without downloading full history.
+        run_cmd! {
+            git init -q $path_str;
+            git -C $path_str remote add origin $PJDFSTEST_REPO;
+            git -C $path_str fetch --depth 1 origin $PJDFSTEST_COMMIT;
+            git -C $path_str checkout -q FETCH_HEAD;
+        }?;
+    }
+    // Drop the hand-rolled config.h next to pjdfstest.c and compile
+    // the single source file directly. Skips autotools so the build
+    // works on a barebones host (just gcc + make).
+    std::fs::write(path.join("config.h"), LINUX_CONFIG_H)?;
+    println!("  compiling pjdfstest (single-source, hand-rolled config.h)");
+    let path_for_cmd = path_str.clone();
+    run_cmd! {
+        cd $path_for_cmd;
+        cc -Wall -include config.h -o pjdfstest pjdfstest.c;
+    }?;
+    if !binary.exists() {
+        return Err(std::io::Error::other(format!(
+            "pjdfstest build did not produce {}",
+            binary.display()
+        )));
+    }
+    Ok(())
+}
+
+fn disk_cache_path() -> String {
+    let base = std::env::current_dir().expect("Failed to get cwd");
+    base.join("data/fuse_test_disk_cache")
+        .to_string_lossy()
+        .to_string()
+}
+
+fn fs_cfg(bucket: &str) -> FsServerConfig {
+    FsServerConfig {
+        bucket_name: bucket.to_string(),
+        mount_point: MOUNT_POINT.to_string(),
+        read_write: true,
+        disk_cache_enabled: false,
+        disk_cache_path: disk_cache_path(),
+        ..Default::default()
+    }
+}
+
+fn mount_fuse_default(bucket: &str) -> CmdResult {
+    let mount_point = MOUNT_POINT;
+    run_cmd! {
+        ignore fusermount3 -u $mount_point 2>/dev/null;
+        ignore fusermount -u $mount_point 2>/dev/null;
+    }?;
+    run_cmd!(mkdir -p $mount_point)?;
+
+    let mut cfg = fs_cfg(bucket);
+    cfg.mode = "default".to_string();
+    cmd_service::init_service(
+        ServiceName::FsServer,
+        crate::cmd_build::BuildMode::Debug,
+        &InitConfig {
+            fs_server: cfg,
+            ..Default::default()
+        },
+    )?;
+    cmd_service::start_service(ServiceName::FsServer)?;
+
+    for _ in 0..40 {
+        std::thread::sleep(Duration::from_millis(500));
+        if run_cmd!(mountpoint -q $mount_point).is_ok() {
+            return Ok(());
+        }
+    }
+    Err(std::io::Error::other(format!(
+        "FUSE mount at {mount_point} not ready after 20 seconds"
+    )))
+}
+
+fn unmount() -> CmdResult {
+    let mount_point = MOUNT_POINT;
+    run_cmd! {
+        ignore fusermount3 -u $mount_point 2>/dev/null;
+        ignore fusermount -u $mount_point 2>/dev/null;
+    }?;
+    let _ = cmd_service::stop_service(ServiceName::FsServer);
+    run_cmd! { ignore pkill -x fs_server 2>/dev/null; }?;
+    std::thread::sleep(Duration::from_millis(500));
+    Ok(())
+}
+
+pub async fn run_pjdfstest(subdir: Option<&str>) -> CmdResult {
+    ensure_pjdfstest_built()?;
+
+    // Use a dedicated bucket so prior runs don't pollute the namespace.
+    let bucket_name = "fs-pjdfs";
+    let _ctx = {
+        let ctx = test_common::context();
+        ctx.create_bucket(bucket_name).await;
+        ctx
+    };
+
+    mount_fuse_default(bucket_name)?;
+    println!("  FUSE mounted at {MOUNT_POINT} (writeback=default)");
+
+    // pjdfstest expects to be run from a working dir that is itself
+    // a writable test root. It creates files / dirs in `.` and
+    // expects the local `pjdfstest` binary to be on PATH.
+    let test_root = format!("{MOUNT_POINT}/pjdfstest-root");
+    std::fs::create_dir_all(&test_root)?;
+
+    let pjd_dir = pjdfstest_path();
+    let bin = pjdfstest_binary();
+    let bin_dir = bin
+        .parent()
+        .expect("binary parent")
+        .to_string_lossy()
+        .to_string();
+
+    // Run the prove suite. The standard layout is
+    // `tests/<group>/NN.t`. Pass `-r` to recurse, `-v` for verbose
+    // (so failures land in our log). When a subdir is given, scope
+    // to that one group; otherwise run everything.
+    let prove_target = match subdir {
+        Some(s) => format!("{}/tests/{}", pjd_dir.display(), s),
+        None => format!("{}/tests", pjd_dir.display()),
+    };
+    println!("  running prove against {prove_target}");
+
+    // Prepend the pjdfstest dir to PATH so the .t scripts find the
+    // binary; run prove from the test root so it creates files there.
+    let path_env = std::env::var("PATH").unwrap_or_default();
+    let prove_env = vec![format!("PATH={bin_dir}:{path_env}")];
+
+    let prove_result = run_cmd! {
+        cd $test_root;
+        $[prove_env] prove -r $prove_target;
+    };
+
+    unmount()?;
+
+    match prove_result {
+        Ok(()) => println!("  pjdfstest: all subgroups passed"),
+        // Per-suite failures are common (chflags, capabilities, ACLs
+        // that fs_server doesn't expose). Surface as a warning, not
+        // a hard error, so the workload-validation flow stays unblocked.
+        Err(e) => eprintln!(
+            "  pjdfstest reported failures ({e}) -- inspect the prove log \
+             above for which subgroups failed."
+        ),
+    }
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -605,6 +605,17 @@ pub enum TestType {
         #[clap(long, help = "Run only with disk cache enabled")]
         disk_cache_only: bool,
     },
+    /// Build (on first run) and execute the pjdfstest POSIX
+    /// compliance suite against a FUSE mount in writeback default
+    /// mode. Optionally restrict to a single subgroup with
+    /// `--subdir chmod` etc.
+    Pjdfstest {
+        #[clap(
+            long,
+            help = "Restrict to a single tests/<NAME>/ subgroup (e.g. chmod, mkdir, rename)"
+        )]
+        subdir: Option<String>,
+    },
 }
 
 #[derive(Parser, Clone, EnumString)]


### PR DESCRIPTION
First slice of the sparse-override / writeback-cache work, split off
`main` so it can land independently of the rest of the stack. Three
commits:

- test(xtask): pjdfstest POSIX compliance suite driver.
- feat(object_layout): `blob_version` field for V1 sparse override.
- feat(fs_server): inode-scoped write lock -- at most one write-mode
  handle per inode, so concurrent partial writes can't silently
  overwrite each other once the buffer goes sparse.

These are foundational (no behavior change to existing paths beyond the
write lock); CI validates the build/tests at this base.
