### PR TITLE
fix(fs_server): seed real owner into listing-materialised directory inodes

### DIFF
--- a/crates/fractal-vfs/src/inode.rs
+++ b/crates/fractal-vfs/src/inode.rs
@@ -73,6 +73,15 @@ pub struct InodeEntry {
     /// flush reads it back and folds it into the layout it serialises
     /// so the changes survive the close-time round-trip.
     pub posix: PosixAttrs,
+    /// `false` when `posix` is a placeholder default, not the inode's
+    /// authoritative owner/mode. A directory materialised from a
+    /// delimiter listing (readdir common-prefix, lookup prefix-listing
+    /// fallback) has no layout to seed from, so its `posix` defaults to
+    /// uid 0 / mode 0; trusting that default makes the setattr owner
+    /// check reject the real owner with EPERM. The async attr paths
+    /// (`vfs_getattr`, `lookup_or_insert` when a marker arrives) refresh
+    /// `posix` from the NSS marker and flip this true.
+    pub posix_known: bool,
     /// `true` once unlink/rmdir has removed the name mapping for this
     /// inode and issued the NSS delete. The kernel's dcache may still
     /// hold a stale dentry pointing at this inode; subsequent FUSE
@@ -101,12 +110,16 @@ pub struct InodeEntry {
 impl InodeEntry {
     fn new(s3_key: String, entry_type: EntryType, layout: Option<ObjectLayout>) -> Self {
         let posix = layout.as_ref().map(layout_posix).unwrap_or_default();
+        // Authoritative only when seeded from a layout; a `None` seed
+        // leaves `posix` at its default placeholder.
+        let posix_known = layout.is_some();
         Self {
             s3_key,
             entry_type,
             layout,
             cache_expiry: Instant::now(),
             posix,
+            posix_known,
             name_removed: false,
             atime_ns: 0,
             inode_id: None,
@@ -157,6 +170,10 @@ impl InodeTable {
                 layout: None,
                 cache_expiry: Instant::now(),
                 posix: PosixAttrs::default(),
+                // Root has no NSS marker; make_dir_attr special-cases it
+                // (mode 0o777) and it is never owner-checked, so treat its
+                // placeholder posix as authoritative to skip marker fetches.
+                posix_known: true,
                 name_removed: false,
                 atime_ns: 0,
                 inode_id: None,
@@ -187,6 +204,15 @@ impl InodeTable {
                 if let Some(new_layout) = layout
                     && let Some(mut entry) = self.map.get_mut(&ino)
                 {
+                    // Seed authoritative posix into an entry whose owner/mode
+                    // is still a listing-materialised placeholder. Guarded on
+                    // `!posix_known` so a real (possibly locally-mutated,
+                    // not-yet-flushed) posix is never clobbered by a stale
+                    // marker.
+                    if !entry.posix_known {
+                        entry.posix = layout_posix(&new_layout);
+                        entry.posix_known = true;
+                    }
                     entry.layout = Some(new_layout);
                     entry.cache_expiry = Instant::now();
                 }
@@ -331,5 +357,87 @@ impl InodeTable {
             }
         }
         evicted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use data_types::object_layout::DirectoryData;
+
+    fn dir_layout(uid: u32, gid: u32, mode: u32) -> ObjectLayout {
+        ObjectLayout {
+            timestamp: 0,
+            version_id: ObjectLayout::gen_version_id(),
+            block_size: 4096,
+            blob_version: 1,
+            state: ObjectState::Directory(DirectoryData {
+                posix: PosixAttrs {
+                    mode,
+                    uid,
+                    gid,
+                    mtime_ns: 0,
+                    ctime_ns: 0,
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn none_seed_dir_is_posix_unknown_then_refreshes_from_marker() {
+        let table = InodeTable::new();
+        let key = "d/";
+
+        // readdir common-prefix / lookup prefix-fallback: no layout, so the
+        // owner is a placeholder and must be flagged not-authoritative.
+        let (ino, is_new) = table.lookup_or_insert(key, EntryType::Directory, None);
+        assert!(is_new, "first insert allocates a new inode");
+        {
+            let e = table.get(ino).expect("entry present");
+            assert!(!e.posix_known, "None-seed dir must be posix-unknown");
+            assert_eq!(e.posix.uid, 0, "placeholder owner is uid 0");
+        }
+
+        // A later lookup that reads the authoritative marker seeds the real
+        // owner into the existing (poisoned) entry and marks it known.
+        let (ino2, is_new2) = table.lookup_or_insert(
+            key,
+            EntryType::Directory,
+            Some(dir_layout(1000, 1001, 0o755)),
+        );
+        assert_eq!(ino2, ino, "same key resolves to the same inode");
+        assert!(!is_new2, "second lookup reuses the entry");
+        let e = table.get(ino).expect("entry present");
+        assert!(e.posix_known, "marker lookup marks posix authoritative");
+        assert_eq!(e.posix.uid, 1000, "owner refreshed from the marker");
+        assert_eq!(e.posix.gid, 1001, "group refreshed from the marker");
+    }
+
+    #[test]
+    fn known_posix_is_not_clobbered_by_a_later_marker() {
+        // A dir seeded from its marker (known), then locally chmod'd but not
+        // yet flushed, must not be reverted by a subsequent marker-bearing
+        // lookup carrying the stale mode.
+        let table = InodeTable::new();
+        let key = "d/";
+        let (ino, _) = table.lookup_or_insert(
+            key,
+            EntryType::Directory,
+            Some(dir_layout(1000, 1000, 0o755)),
+        );
+        {
+            let mut e = table.get_mut(ino).expect("entry present");
+            e.posix.mode = 0o700; // unflushed local chmod
+        }
+        table.lookup_or_insert(
+            key,
+            EntryType::Directory,
+            Some(dir_layout(1000, 1000, 0o755)),
+        );
+        let e = table.get(ino).expect("entry present");
+        assert_eq!(
+            e.posix.mode, 0o700,
+            "known (locally mutated) posix must survive a stale marker lookup"
+        );
     }
 }

--- a/crates/fractal-vfs/src/vfs.rs
+++ b/crates/fractal-vfs/src/vfs.rs
@@ -2746,6 +2746,12 @@ impl VfsCore {
             return Ok(self.make_new_file_attr(inode, wb.file_size));
         }
 
+        // A directory materialised from a delimiter listing carries only
+        // placeholder posix (uid 0 / mode 0); fetch its marker so stat and
+        // the setattr owner check see the real owner. No-op for files or an
+        // already-authoritative entry.
+        self.refresh_dir_posix_if_unknown(inode).await;
+
         let entry = self.inodes.get(inode).ok_or(FsError::NotFound)?;
 
         match entry.entry_type {
@@ -2893,6 +2899,36 @@ impl VfsCore {
             .get(inode)
             .map(|e| e.inode_id.is_some())
             .unwrap_or(false)
+    }
+
+    pub fn is_dir(&self, inode: u64) -> bool {
+        self.inodes
+            .get(inode)
+            .map(|e| e.entry_type == EntryType::Directory)
+            .unwrap_or(false)
+    }
+
+    /// Seed authoritative posix into a directory entry whose owner/mode is
+    /// still a listing-materialised placeholder (`posix_known == false`),
+    /// by reading its NSS marker. No-op for files, the root, an entry with
+    /// known posix, or a marker that has no directory layout (a legacy
+    /// Normal marker / implicit directory keeps its default). Guarded on
+    /// `!posix_known` again after the fetch so a concurrent local posix
+    /// mutation is never clobbered.
+    async fn refresh_dir_posix_if_unknown(&self, inode: u64) {
+        let dir_key = match self.inodes.get(inode) {
+            Some(e) if e.entry_type == EntryType::Directory && !e.posix_known => e.s3_key.clone(),
+            _ => return,
+        };
+        let trace_id = TraceId::new();
+        if let Ok(layout) = self.backend().get_inode(&dir_key, &trace_id).await
+            && layout.is_directory()
+            && let Some(mut e) = self.inodes.get_mut(inode)
+            && !e.posix_known
+        {
+            e.posix = crate::inode::layout_posix(&layout);
+            e.posix_known = true;
+        }
     }
 
     pub fn vfs_getattr_inmem(&self, inode: u64, fh: Option<u64>) -> Result<VfsAttr, FsError> {
@@ -4780,6 +4816,35 @@ impl VfsCore {
         let dir_entries = self.fetch_dir_entries(parent, &prefix).await?;
 
         let offset = offset as usize;
+
+        // A subdirectory row comes from the delimiter listing as a
+        // common-prefix with no posix, so its entry carries the uid-0
+        // placeholder. Seed the real owner from each marker before building
+        // attrs, or readdirplus emits uid 0 and the kernel caches it (a
+        // later stat/chmod then sees the placeholder owner). Concurrent to
+        // bound the cost on a cold `ls` of a many-subdir directory; a
+        // posix-known entry is skipped, so repeat listings pay nothing.
+        let unknown_dirs: Vec<u64> = dir_entries
+            .iter()
+            .skip(offset)
+            .filter(|e| e.kind.is_dir())
+            .map(|e| e.ino)
+            .filter(|&ino| {
+                self.inodes
+                    .get(ino)
+                    .map(|e| !e.posix_known)
+                    .unwrap_or(false)
+            })
+            .collect();
+        if !unknown_dirs.is_empty() {
+            futures::future::join_all(
+                unknown_dirs
+                    .into_iter()
+                    .map(|ino| self.refresh_dir_posix_if_unknown(ino)),
+            )
+            .await;
+        }
+
         let trace_id = TraceId::new();
         let mut entries: Vec<VfsDirEntryPlus> =
             Vec::with_capacity(dir_entries.len().saturating_sub(offset));

--- a/crates/fs_server/src/fuse_server.rs
+++ b/crates/fs_server/src/fuse_server.rs
@@ -131,9 +131,13 @@ impl Filesystem for FuseServer {
         // block.
         if req.uid != 0 {
             // In-memory attrs are sufficient for ordinary inodes. Hardlinks
-            // store owner/mode in the shared NSS record, so permission checks
-            // must read the authoritative record instead of a stale alias cache.
-            let cur = if self.vfs.is_hardlink(inode) {
+            // store owner/mode in the shared NSS record, and a directory
+            // materialised from a delimiter listing carries only placeholder
+            // posix (uid 0); both must read the authoritative owner via the
+            // async path (which refreshes from the NSS marker) instead of a
+            // stale/placeholder in-memory value, or the owner check rejects
+            // the real owner with EPERM.
+            let cur = if self.vfs.is_hardlink(inode) || self.vfs.is_dir(inode) {
                 self.vfs.vfs_getattr(inode, fh).await.map_err(fs_err)?
             } else {
                 self.vfs.vfs_getattr_inmem(inode, fh).map_err(fs_err)?

--- a/xtask/src/cmd_run_tests/fs_server/fuse.rs
+++ b/xtask/src/cmd_run_tests/fs_server/fuse.rs
@@ -359,6 +359,10 @@ async fn run_fuse_test_suite(disk_cache: bool) -> CmdResult {
         "Cross-Instance Overwrite Visibility",
         test_cross_instance_overwrite_visibility
     );
+    run_test!(
+        "Cross-Instance Directory Owner After Listing",
+        test_cross_instance_dir_owner_after_listing
+    );
 
     // Destructive: stops/starts bss@0 to exercise override durability
     // across a replica partition+rejoin. Run it ONCE (no-cache phase) and
@@ -2107,6 +2111,68 @@ async fn test_cross_instance_overwrite_visibility(disk_cache: bool) -> CmdResult
     println!(
         "{}",
         "SUCCESS: Cross-instance overwrite visibility test passed".green()
+    );
+    Ok(())
+}
+
+/// Regression: a directory first materialised on a second instance via a
+/// delimiter listing (readdir) must report its real owner, not the uid-0
+/// placeholder the common-prefix listing seeds. Before the fix nothing
+/// refreshed that placeholder, so `stat` reported uid 0 and a `chmod` /
+/// `utime` by the true owner got EPERM. This is the cross-instance analogue
+/// of the single-mount forget+relookup case (tar's dir-metadata pass
+/// failing under kernel inode-cache pressure during a large untar).
+async fn test_cross_instance_dir_owner_after_listing(disk_cache: bool) -> CmdResult {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let (_ctx, bucket) = setup_test_bucket().await;
+
+    println!("  Step 1: Mount instance A (read-write)");
+    mount_fuse_rw(&bucket, disk_cache)?;
+
+    println!("  Step 2: mkdir on A (owned by the mounting user) with a child");
+    let dir = "owned-dir";
+    let path_a = format!("{}/{}", MOUNT_POINT, dir);
+    std::fs::create_dir(&path_a).expect("mkdir on A");
+    // A child key makes the dir surface as a listing common-prefix on B.
+    std::fs::write(format!("{path_a}/child.txt"), b"x").expect("write child on A");
+
+    println!("  Step 3: Spawn instance B (read-write) on same bucket");
+    let child_b = spawn_second_fuse(&bucket, true)?;
+    std::thread::sleep(CACHE_TTL_WAIT);
+
+    println!("  Step 4: Materialise B's entry via a directory listing (readdir)");
+    let names: Vec<String> = std::fs::read_dir(MOUNT_POINT_B)
+        .expect("readdir B")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        names.contains(&dir.to_string()),
+        "dir not listed on B: {names:?}"
+    );
+
+    println!("  Step 5: stat on B reports the real owner, not the uid-0 placeholder");
+    let uid = unsafe { libc::getuid() };
+    let path_b = format!("{}/{}", MOUNT_POINT_B, dir);
+    let meta = std::fs::metadata(&path_b).expect("stat B");
+    assert_eq!(
+        meta.uid(),
+        uid,
+        "listing-materialised dir on B reports placeholder owner {} (expected {uid})",
+        meta.uid()
+    );
+
+    println!("  Step 6: chmod on B by the owner succeeds (no EPERM)");
+    std::fs::set_permissions(&path_b, std::fs::Permissions::from_mode(0o0755))
+        .expect("chmod on B must not EPERM for the real owner");
+
+    stop_second_fuse(child_b);
+    unmount_fuse()?;
+
+    println!(
+        "{}",
+        "SUCCESS: Cross-instance directory owner after listing test passed".green()
     );
     Ok(())
 }


### PR DESCRIPTION
## Problem

A delimiter listing returns a subdirectory as a common prefix with no posix, so its inode entry defaulted to uid 0 / mode 0 and nothing ever refreshed it. `stat`/`ls` then reported root ownership, and `chmod` / `chown` / `utimensat` by the true owner were rejected with EPERM. This surfaced as tar directory-metadata failures during a large untar, where kernel inode-cache pressure evicted directories mid-run and a later listing re-materialised them with the placeholder owner.

## Fix

Seed authoritative posix from the NSS marker at every path that can observe a directory, guarded by a new `posix_known` flag so a locally mutated, not-yet-flushed posix is never clobbered by a stale marker:

- readdirplus attr build (concurrent per page, cached after the first)
- getattr / setattr on an unknown-owner directory
- `lookup_or_insert` when a marker arrives for an already-poisoned entry

## Testing

- New cross-instance regression test (`ls` on a second instance, then `stat`/`chmod`): red before this change ("placeholder owner 0"), green after.
- Full `cargo xtask run-tests fs-server` suite: 112/112.
- `fractal-vfs` unit tests cover the `lookup_or_insert` refresh.